### PR TITLE
Fast Travel Crash Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ luac.out
 *.x86_64
 *.hex
 
+# VSCode workspace settings
+.vscode/

--- a/DefaultConfig.ini
+++ b/DefaultConfig.ini
@@ -1,0 +1,11 @@
+[Framerate]
+MaxFPS=0
+VSyncInterval=1
+UseFixed=false
+
+[Graphics]
+TemporalUpscaling=true
+MotionBlur=true
+
+[Misc]
+ShowFPSStats=false

--- a/Mods/DBZK_Fix/Scripts/main.lua
+++ b/Mods/DBZK_Fix/Scripts/main.lua
@@ -1,4 +1,8 @@
 ---@diagnostic disable: undefined-global
+
+--- @type string
+local version = '0.3'
+
 local UEHelpers = require("UEHelpers")
 local inifile = require("inifile");
 
@@ -126,18 +130,18 @@ function Init()
     
     init = true
 
-    LogPrint("Initializing...")
+    print("Initializing " .. 'v' .. version .. " of DBZK_Fix!\n")
 end
 
 Init()
 
 RegisterHook("/Script/AT.ATSaveManager:Load", function()
-    print("[DBZK_Fix] Loading...")
+    LogPrint("Loading...")
     Fix()
 end)
 
 RegisterHook("/Script/AT.ATSaveManager:Save", function()
-    print("[DBZK_Fix] Saving...")
+    LogPrint("Saving...")
     Fix()
 end)
 


### PR DESCRIPTION
## Bug Fixes
* #2 Looks like this hook: `/Script/Engine.PlayerController:ClientRestart` was causing the crashes on fast travel in my testing. All it was calling was FPS uncap, the TAA stuff, V-SYNC, and Motion Blur handlers, all of which seemed to be still working after taking it out 🤷.

## Features
* New feature alert!! Added a config option in Config.ini to use the `FixedFrameRate` method of capping FPS. In my experience, it just _feels_ a touch smoother than the usual method, but frame-pacing graphs look mostly the same.
  * **NOTE**: You should be using this with a cap in Config.ini and not the default uncapped value of 0. I believe this will properly slow your game down if you cannot hit the frame rate you've targeted, so don't use this if you have performance issues!

## Misc.
* Cleaned up some of the Lua type hints and comments and things...tried to clear away some warnings in VSCode.
* Added the version of the script in the log